### PR TITLE
CI for goma-input-processor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: build 
+# This workflow is triggered on pushes to the repository.
+on: [push]
+
+jobs:
+  build-linux:
+    name: build-linux
+    runs-on: ubuntu-latest
+    container: tipibuild/tipi-ubuntu:latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          path: 'client'
+      - name: setup depot_tools
+        run: |
+          git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git      
+          echo $PWD/depot_tools/ >> $GITHUB_PATH
+          python3 --version
+          $PWD/depot_tools/gclient
+          
+      - name: build goma-input-processor
+        run: |
+          gclient config https://chromium.googlesource.com/infra/goma-input-processor --name=client --unmanaged
+          gclient sync --no-history
+          cd client/
+          gn gen --args="is_debug=false agnostic_build=true" out/Release
+          ninja -C out/Release/
+
+      - name: unit tests
+        run: |
+          cd client/
+          export GTEST_FILTER="-CompilerInfoBuilderTest.*:ElfParserTest.*:ElfDepParserTest.*:GCCCompilerInfoBuilderTest.*:CppIncludeProcessorPosixTest.*:LinkerInputProcessorTest.*"
+          ./build/run_unittest.py --target=Release --build-dir=out --non-stop


### PR DESCRIPTION
This enables all test suites that were passing in e9dfe680f70abeaddf44356983a3e02e6afb5b73 to keep a stable goma-input-processor

- Relates to tipi-build/specs-cmake-re#136